### PR TITLE
Add fast BLANC computation

### DIFF
--- a/scorch/scores.py
+++ b/scorch/scores.py
@@ -311,19 +311,20 @@ class AdjacencyReturn(ty.NamedTuple):
 
 
 def adjacency(
-    clusters: ty.Sequence[ty.Sequence[int]], num_elts: int
+    clusters: ty.List[ty.List[int]], num_elts: int
 ) -> AdjacencyReturn:
     adjacency = np.zeros((num_elts, num_elts), dtype=np.bool)
     presence = np.zeros(num_elts, dtype=np.bool)
-    # FIXME: the complexity of this is `$∑|c|²$`, so it is fast when there are many small clusters
-    # but slow when there are big clusters
+    # **Note** The nested loop makes the complexity of this `$∑|c|²$` but we are only doing memory
+    # access, which is really fast, so this is not really an issue. As comparison, doing it by
+    # computing the Gram matrix one-hot elt-cluster attribution matrix was making `fast_blanc` 3×
+    # slower than the naïve version.
     for c in clusters:
-        for i, e in enumerate(c[:-1]):
+        for e in c:
             presence[e] = True
-            for f in c[i + 1 :]:
-                adjacency[e, f] = True
-                adjacency[f, e] = True
-        presence[c[-1]] = True
+            for f in c:
+                if f != e:
+                    adjacency[e, f] = True
     return AdjacencyReturn(adjacency, presence)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 classifiers =
     License :: OSI Approved :: MIT License
-    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.8
     Environment :: Console
 keywords =
     nlp

--- a/tests/speedtest.py
+++ b/tests/speedtest.py
@@ -31,21 +31,21 @@ def test_blanc_speedup(clusters: Clustering, num_runs: int = 100, repeat: int = 
     slow_runtime = min(
         timeit.repeat(
             "blanc(clusters, clusters, False)",
-            globals={"fun": scores.blanc, "clusters": clusters},
+            globals={"blanc": scores.blanc, "clusters": clusters},
             number=num_runs,
             repeat=repeat,
         )
     )
-    print(f"Slow\t{slow_runtime} s ({slow_runtime/num_runs} s/call)")
+    print(f"Slow:\t{slow_runtime} s ({slow_runtime/num_runs} s/call)")
     fast_runtime = min(
         timeit.repeat(
             "blanc(clusters, clusters,)",
-            globals={"fun": scores.blanc, "clusters": clusters},
+            globals={"blanc": scores.blanc, "clusters": clusters},
             number=num_runs,
             repeat=repeat,
         )
     )
-    print(f"Fast\t{fast_runtime} s ({fast_runtime/num_runs} s/call)")
+    print(f"Fast:\t{fast_runtime} s ({fast_runtime/num_runs} s/call)")
     print(f"Speedup: ×{slow_runtime/fast_runtime}")
 
 

--- a/tests/speedtest.py
+++ b/tests/speedtest.py
@@ -1,8 +1,8 @@
-import itertools as it
 import pathlib
 import timeit
 import typing as ty
 
+from scorch import scores
 from scorch import main as scorch
 
 
@@ -10,11 +10,14 @@ tests_dir = pathlib.Path(__file__).resolve().parent
 
 
 def test_metrics(
-    clusters: ty.Sequence[ty.Set[ty.Hashable]], num_runs: int = 100, repeat: int = 5
+    clusters: ty.Sequence[ty.Set[ty.Hashable]], num_runs: int = 100, repeat: int = 1
 ):
     print(f"Testing metrics speed: {num_runs} calls, best of {repeat}")
     print("metric\ttotal\tper call")
-    for (name, fun) in scorch.METRICS.items():
+    for (name, fun) in {
+        **scorch.METRICS,
+        "Slow BLANC": lambda x, y: scores.blanc(x, y, False),
+    }.items():
         runtime = min(
             timeit.repeat(
                 "fun(clusters, clusters)",
@@ -26,27 +29,7 @@ def test_metrics(
         print(f"{name}\t{runtime}\t{runtime/num_runs}")
 
 
-def remap_clusterings(
-    clusterings: ty.Sequence[ty.Sequence[ty.Set[ty.Hashable]]],
-) -> ty.List[ty.List[ty.Set[int]]]:
-    """Remap clusterings of arbitrary elements to clusterings of integers for faster operations."""
-    elts = set(e for clusters in clusterings for c in clusters for e in c)
-    elts_map = {e: i for i, e in enumerate(elts)}
-    res = []
-    for clusters in clusterings:
-        remapped_clusters = []
-        for c in clusters:
-            remapped_c = set(elts_map[e] for e in c)
-            remapped_clusters.append(remapped_c)
-        res.append(remapped_clusters)
-    return res
-
-
 with open(tests_dir / "fixtures" / "clusters.json") as in_stream:
     clusters = scorch.clusters_from_json(in_stream)
 
 test_metrics(clusters)
-
-remapped = remap_clusterings([clusters])[0]
-
-test_metrics(remapped)

--- a/tests/speedtest.py
+++ b/tests/speedtest.py
@@ -8,16 +8,13 @@ from scorch import main as scorch
 
 tests_dir = pathlib.Path(__file__).resolve().parent
 
+Clustering = ty.Sequence[ty.Set[ty.Hashable]]
 
-def test_metrics(
-    clusters: ty.Sequence[ty.Set[ty.Hashable]], num_runs: int = 100, repeat: int = 1
-):
+
+def test_metrics(clusters: Clustering, num_runs: int = 100, repeat: int = 5):
     print(f"Testing metrics speed: {num_runs} calls, best of {repeat}")
     print("metric\ttotal\tper call")
-    for (name, fun) in {
-        **scorch.METRICS,
-        "Slow BLANC": lambda x, y: scores.blanc(x, y, False),
-    }.items():
+    for (name, fun) in scorch.METRICS.items():
         runtime = min(
             timeit.repeat(
                 "fun(clusters, clusters)",
@@ -29,7 +26,32 @@ def test_metrics(
         print(f"{name}\t{runtime}\t{runtime/num_runs}")
 
 
+def test_blanc_speedup(clusters: Clustering, num_runs: int = 100, repeat: int = 5):
+    print(f"Testing BLANC speedup: {num_runs} calls, best of {repeat}")
+    slow_runtime = min(
+        timeit.repeat(
+            "blanc(clusters, clusters, False)",
+            globals={"fun": scores.blanc, "clusters": clusters},
+            number=num_runs,
+            repeat=repeat,
+        )
+    )
+    print(f"Slow\t{slow_runtime} s ({slow_runtime/num_runs} s/call)")
+    fast_runtime = min(
+        timeit.repeat(
+            "blanc(clusters, clusters,)",
+            globals={"fun": scores.blanc, "clusters": clusters},
+            number=num_runs,
+            repeat=repeat,
+        )
+    )
+    print(f"Fast\t{fast_runtime} s ({fast_runtime/num_runs} s/call)")
+    print(f"Speedup: ×{slow_runtime/fast_runtime}")
+
+
 with open(tests_dir / "fixtures" / "clusters.json") as in_stream:
     clusters = scorch.clusters_from_json(in_stream)
 
 test_metrics(clusters)
+
+test_blanc_speedup(clusters)

--- a/tests/speedtest.py
+++ b/tests/speedtest.py
@@ -9,12 +9,18 @@ from scorch import main as scorch
 tests_dir = pathlib.Path(__file__).resolve().parent
 
 Clustering = ty.Sequence[ty.Set[ty.Hashable]]
+Metric = ty.Callable[[Clustering, Clustering], ty.Tuple[float, float, float]]
 
 
-def test_metrics(clusters: Clustering, num_runs: int = 100, repeat: int = 5):
+def test_metrics(
+    clusters: Clustering,
+    num_runs: int = 100,
+    repeat: int = 5,
+    metrics: ty.Dict[str, Metric] = scorch.METRICS,
+):
     print(f"Testing metrics speed: {num_runs} calls, best of {repeat}")
     print("metric\ttotal\tper call")
-    for (name, fun) in scorch.METRICS.items():
+    for (name, fun) in metrics.items():
         runtime = min(
             timeit.repeat(
                 "fun(clusters, clusters)",

--- a/tests/test_scores_sanity.py
+++ b/tests/test_scores_sanity.py
@@ -25,6 +25,6 @@ def test_perfect_muc(clusters: ty.Sequence[ty.Set[int]]):
 
 @hypothesis.given(key=clusterings(max_size=256), response=clusterings(max_size=256))
 def test_blanc_consistency(key, response):
-    fast_blanc = scores.blanc(key, response, fast=True)
-    slow_blanc = scores.blanc(key, response, fast=False)
+    fast_blanc = scores.fast_detailed_blanc(key, response)
+    slow_blanc = scores.detailed_blanc(key, response)
     assert fast_blanc == slow_blanc

--- a/tests/test_scores_sanity.py
+++ b/tests/test_scores_sanity.py
@@ -21,3 +21,10 @@ def test_perfect(metric, clusters: ty.Sequence[ty.Set[int]]):
 def test_perfect_muc(clusters: ty.Sequence[ty.Set[int]]):
     """Test that all the scores are `1.0` for a perfect system output for MUC"""
     assert scores.muc(clusters, clusters) == (1.0, 1.0, 1.0)
+
+
+@hypothesis.given(key=clusterings(max_size=256), response=clusterings(max_size=256))
+def test_blanc_consistency(key, response):
+    fast_blanc = scores.blanc(key, response, fast=True)
+    slow_blanc = scores.blanc(key, response, fast=False)
+    assert fast_blanc == slow_blanc


### PR DESCRIPTION
- Add a faster BLANC implementation and a corresponding out-out parameter to `scores.blanc`.
- Add sanity checks to ensure that the slow and fast versions give the same results

Perf gains:

```
100 calls, best of 5
Slow:   66.60733144904952 s (0.6660733144904952 s/call)
Fast:   0.7983404429396614 s (0.007983404429396615 s/call)
Speedup: ×83.43224001503292
```

We still keep the slow version because it is far more straightforward (it's a direct translation from the definition) and therefore much easier to check for correctness.